### PR TITLE
Upgrade to pre-commit python 3.9

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,7 +3,7 @@ name: MetaQS push actions
 on:
   push:
     branches:
-      - "*"
+      - "**"
 
 env:
   docker_repository: "docker.edu-sharing.com"

--- a/src/.pre-commit-config.yaml
+++ b/src/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 default_language_version:
-  python: python3.7.4
+    python: python3.9
 
 repos:
   - repo: https://github.com/ambv/black
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.7.4
+        language_version: python3.9
   - repo: https://github.com/PyCQA/isort
     rev: 5.6.4
     hooks:


### PR DESCRIPTION
Bumps python version of pre-commit hook to 3.9 (same as specified in pyproject.toml).