### PR TITLE
Fixing ROOT_PATH 

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,7 +45,7 @@ services:
       - fastapi
     environment:
       NGINX_HOST: "${NGINX_HOST}"
-      ROOT_PATH: ""
+      ROOT_PATH: "/api"
     volumes:
       - ./nginx/nginx-ssl.conf.template:/etc/nginx/templates/default.conf.template:ro
       - ./nginx/certbot/conf:/etc/letsencrypt
@@ -94,7 +94,7 @@ services:
     environment:
       <<: *postgres-vars
       POSTGRES_HOST: postgres
-      ROOT_PATH: ""
+      ROOT_PATH: "/api"
       API_VERSION: "${API_VERSION:-v1}"
       API_KEY: "${API_KEY:-openeduhub}"
       ALLOWED_HOSTS: "${ALLOWED_HOSTS:-*}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - fastapi
     environment:
       NGINX_HOST: "${NGINX_HOST}"
-      ROOT_PATH: "/"
+      ROOT_PATH: "/api"
     volumes:
       - ./nginx/nginx-ssl.conf.template:/etc/nginx/templates/default.conf.template:ro
       - ./nginx/certbot/conf:/etc/letsencrypt
@@ -96,7 +96,7 @@ services:
     environment:
       <<: *postgres-vars
       POSTGRES_HOST: postgres
-      ROOT_PATH: "/"
+      ROOT_PATH: "/api"
       API_VERSION: "${API_VERSION:-v1}"
       API_KEY: "${API_KEY:-openeduhub}"
       ALLOWED_HOSTS: "${ALLOWED_HOSTS:-*}"

--- a/src/app/api/quality_matrix/quality_matrix.py
+++ b/src/app/api/quality_matrix/quality_matrix.py
@@ -33,14 +33,14 @@ def create_sources_search(aggregation_name: str):
 
 def extract_sources_from_response(
     response: Response, aggregation_name: str
-) -> dict[str:int]:
+) -> dict[str, int]:
     return {
         entry["key"]: entry["doc_count"]
         for entry in response.aggregations.to_dict()[aggregation_name]["buckets"]
     }
 
 
-def all_sources() -> dict[str:int]:
+def all_sources() -> dict[str, int]:
     aggregation_name = "unique_sources"
     s = create_sources_search(aggregation_name)
     response: Response = s.execute()


### PR DESCRIPTION
Fixing ROOT_PATH to be "/api" since "" would cause the openapi generation in frontend to yield localhost, only.