### PR TITLE
50 bug wrong response type for glom

### DIFF
--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import Mapping, Optional
+from typing import Mapping
 from uuid import UUID
 
 from databases import Database
@@ -18,9 +18,7 @@ from app.api.collections.counts import (
 )
 from app.api.collections.missing_attributes import (
     MissingAttributeFilter,
-    collection_response_fields,
     collections_filter_params,
-    filter_response_fields,
     get_child_collections_with_missing_attributes,
 )
 from app.api.collections.models import CollectionNode, MissingMaterials
@@ -42,7 +40,6 @@ from app.api.score.score import (
 )
 from app.core.constants import COLLECTION_NAME_TO_ID, COLLECTION_ROOT_ID
 from app.elastic.elastic import ResourceType
-from app.models import CollectionAttribute
 
 
 def get_database(request: Request) -> Database:
@@ -270,15 +267,7 @@ async def filter_collections_with_missing_attributes(
     *,
     node_id: UUID = Depends(node_ids_for_major_collections),
     missing_attr_filter: MissingAttributeFilter = Depends(collections_filter_params),
-    source_fields: Optional[set[CollectionAttribute]] = Depends(
-        collection_response_fields
-    ),
 ):
-    if source_fields:
-        source_fields.add(CollectionAttribute.NODEREF_ID)
-
-    collections = await get_child_collections_with_missing_attributes(
+    return await get_child_collections_with_missing_attributes(
         noderef_id=node_id, missing_attr_filter=missing_attr_filter
     )
-
-    return filter_response_fields(collections, response_fields=source_fields)

--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -18,7 +18,7 @@ from app.api.collections.counts import (
 )
 from app.api.collections.missing_attributes import (
     collections_with_missing_attributes,
-    missingPropertyFilter,
+    missing_attribute_filter,
 )
 from app.api.collections.models import CollectionNode, MissingMaterials
 from app.api.collections.tree import collection_tree
@@ -264,14 +264,16 @@ async def get_collection_counts(
     tags=[_TAG_COLLECTIONS],
     description="""A list of missing entries for different types of materials by subcollection.
     Searches for entries with one of the following properties being empty or missing: """
-    + f"{', '.join([entry.value for entry in missingPropertyFilter])}.",
+    + f"{', '.join([entry.value for entry in missing_attribute_filter])}.",
 )
 async def filter_collections_with_missing_attributes(
     *,
     noderef_id: UUID = Depends(node_ids_for_major_collections),
     missing_attribute: str = Path(
         ...,
-        examples={form.name: {"value": form.value} for form in missingPropertyFilter},
+        examples={
+            form.name: {"value": form.value} for form in missing_attribute_filter
+        },
     ),
 ):
     return await collections_with_missing_attributes(noderef_id, missing_attribute)

--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -16,12 +16,11 @@ from app.api.collections.counts import (
     CollectionTreeCount,
     collection_counts,
 )
-from app.api.collections.missing_attributes import collections_with_missing_attributes
-from app.api.collections.models import (
-    CollectionNode,
-    MissingMaterials,
-    MissingPropertyFilter,
+from app.api.collections.missing_attributes import (
+    collections_with_missing_attributes,
+    missingPropertyFilter,
 )
+from app.api.collections.models import CollectionNode, MissingMaterials
 from app.api.collections.tree import collection_tree
 from app.api.quality_matrix.collections import collection_quality
 from app.api.quality_matrix.models import ColumnOutputModel, Forms, Timeline
@@ -265,14 +264,14 @@ async def get_collection_counts(
     tags=[_TAG_COLLECTIONS],
     description="""A list of missing entries for different types of materials by subcollection.
     Searches for entries with one of the following properties being empty or missing: """
-    + f"{', '.join([entry.value for entry in MissingPropertyFilter])}.",
+    + f"{', '.join([entry.value for entry in missingPropertyFilter])}.",
 )
 async def filter_collections_with_missing_attributes(
     *,
     noderef_id: UUID = Depends(node_ids_for_major_collections),
     missing_attribute: str = Path(
         ...,
-        examples={form.name: {"value": form.value} for form in MissingPropertyFilter},
+        examples={form.name: {"value": form.value} for form in missingPropertyFilter},
     ),
 ):
     return await collections_with_missing_attributes(

--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -274,6 +274,4 @@ async def filter_collections_with_missing_attributes(
         examples={form.name: {"value": form.value} for form in missingPropertyFilter},
     ),
 ):
-    return await collections_with_missing_attributes(
-        noderef_id=noderef_id, missing_attribute=missing_attribute
-    )
+    return await collections_with_missing_attributes(noderef_id, missing_attribute)

--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -278,9 +278,7 @@ async def filter_collections_with_missing_attributes(
         source_fields.add(CollectionAttribute.NODEREF_ID)
 
     collections = await get_child_collections_with_missing_attributes(
-        noderef_id=node_id,
-        missing_attr_filter=missing_attr_filter,
-        source_fields=source_fields,
+        noderef_id=node_id, missing_attr_filter=missing_attr_filter
     )
 
     return filter_response_fields(collections, response_fields=source_fields)

--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -16,13 +16,12 @@ from app.api.collections.counts import (
     CollectionTreeCount,
     collection_counts,
 )
-from app.api.collections.missing_attributes import (
-    MissingAttributeFilter,
-    MissingCollectionField,
-    collections_filter_params,
-    collections_with_missing_attributes,
+from app.api.collections.missing_attributes import collections_with_missing_attributes
+from app.api.collections.models import (
+    CollectionNode,
+    MissingMaterials,
+    MissingPropertyFilter,
 )
-from app.api.collections.models import CollectionNode, MissingMaterials
 from app.api.collections.tree import collection_tree
 from app.api.quality_matrix.collections import collection_quality
 from app.api.quality_matrix.models import ColumnOutputModel, Forms, Timeline
@@ -258,7 +257,7 @@ async def get_collection_counts(
 
 
 @router.get(
-    "/collections/{node_id}/pending-subcollections/{missing_attr}",
+    "/collections/{node_id}/pending-subcollections/{missing_attribute}",
     response_model=list[MissingMaterials],
     response_model_exclude_unset=True,
     status_code=HTTP_200_OK,
@@ -266,13 +265,16 @@ async def get_collection_counts(
     tags=[_TAG_COLLECTIONS],
     description="""A list of missing entries for different types of materials by subcollection.
     Searches for entries with one of the following properties being empty or missing: """
-    + f"{', '.join([entry.path for entry in MissingCollectionField])}.",
+    + f"{', '.join([entry.value for entry in MissingPropertyFilter])}.",
 )
 async def filter_collections_with_missing_attributes(
     *,
     noderef_id: UUID = Depends(node_ids_for_major_collections),
-    missing_attr_filter: MissingAttributeFilter = Depends(collections_filter_params),
+    missing_attribute: str = Path(
+        ...,
+        examples={form.name: {"value": form.value} for form in MissingPropertyFilter},
+    ),
 ):
     return await collections_with_missing_attributes(
-        noderef_id=noderef_id, missing_attr_filter=missing_attr_filter
+        noderef_id=noderef_id, missing_attribute=missing_attribute
     )

--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import Mapping
+from typing import Mapping, Optional
 from uuid import UUID
 
 from databases import Database
@@ -16,7 +16,14 @@ from app.api.collections.counts import (
     CollectionTreeCount,
     collection_counts,
 )
-from app.api.collections.models import CollectionNode
+from app.api.collections.missing_attributes import (
+    MissingAttributeFilter,
+    collection_response_fields,
+    collections_filter_params,
+    filter_response_fields,
+    get_child_collections_with_missing_attributes,
+)
+from app.api.collections.models import CollectionNode, MissingMaterials
 from app.api.collections.tree import collection_tree
 from app.api.quality_matrix.collections import collection_quality
 from app.api.quality_matrix.models import ColumnOutputModel, Forms, Timeline
@@ -35,6 +42,7 @@ from app.api.score.score import (
 )
 from app.core.constants import COLLECTION_NAME_TO_ID, COLLECTION_ROOT_ID
 from app.elastic.elastic import ResourceType
+from app.models import CollectionAttribute
 
 
 def get_database(request: Request) -> Database:
@@ -248,3 +256,31 @@ async def get_collection_counts(
 ):
     counts = await collection_counts(node_id=node_id, facet=facet)
     return counts
+
+
+@router.get(
+    "/collections/{node_id}/pending-subcollections/{missing_attr}",
+    response_model=list[MissingMaterials],
+    response_model_exclude_unset=True,
+    status_code=HTTP_200_OK,
+    responses={HTTP_404_NOT_FOUND: {"description": "Collection not found"}},
+    tags=["Collections"],
+)
+async def filter_collections_with_missing_attributes(
+    *,
+    node_id: UUID = Depends(node_ids_for_major_collections),
+    missing_attr_filter: MissingAttributeFilter = Depends(collections_filter_params),
+    source_fields: Optional[set[CollectionAttribute]] = Depends(
+        collection_response_fields
+    ),
+):
+    if source_fields:
+        source_fields.add(CollectionAttribute.NODEREF_ID)
+
+    collections = await get_child_collections_with_missing_attributes(
+        noderef_id=node_id,
+        missing_attr_filter=missing_attr_filter,
+        source_fields=source_fields,
+    )
+
+    return filter_response_fields(collections, response_fields=source_fields)

--- a/src/app/api/collections/missing_attributes.py
+++ b/src/app/api/collections/missing_attributes.py
@@ -8,7 +8,7 @@ from glom import Coalesce, Iter
 from pydantic import BaseModel
 
 from app.api.collections.models import MissingMaterials
-from app.api.collections.utils import hits_to_object
+from app.api.collections.utils import map_elastic_response_to_model
 from app.core.config import ELASTIC_TOTAL_SIZE
 from app.elastic.dsl import qbool, qmatch
 from app.elastic.elastic import ResourceType, type_filter
@@ -16,6 +16,7 @@ from app.elastic.fields import Field
 from app.elastic.search import Search
 from app.models import CollectionAttribute
 
+# TODO Refactor
 MissingCollectionField = Field(
     "MissingCollectionField",
     [
@@ -139,7 +140,7 @@ missing_attributes_spec = {
 }
 
 
-async def get_child_collections_with_missing_attributes(
+async def collections_with_missing_attributes(
     noderef_id: UUID,
     missing_attr_filter: MissingAttributeFilter,
     max_hits: Optional[int] = ELASTIC_TOTAL_SIZE,
@@ -148,4 +149,6 @@ async def get_child_collections_with_missing_attributes(
 
     response = s.execute()
     if response.success():
-        return hits_to_object(response, missing_attributes_spec, MissingMaterials)
+        return map_elastic_response_to_model(
+            response, missing_attributes_spec, MissingMaterials
+        )

--- a/src/app/api/collections/missing_attributes.py
+++ b/src/app/api/collections/missing_attributes.py
@@ -11,27 +11,23 @@ from app.api.collections.utils import map_elastic_response_to_model
 from app.core.config import ELASTIC_TOTAL_SIZE
 from app.elastic.dsl import qbool, qmatch
 from app.elastic.elastic import ResourceType, type_filter
-from app.elastic.fields import Field
+from app.elastic.fields import ElasticField
 from app.elastic.search import Search
-from app.models import (
-    CollectionAttribute,
-    ElasticResourceAttribute,
-    _CollectionAttribute,
-)
+from app.models import CollectionAttribute, ElasticResourceAttribute
 
 
-def qwildcard(qfield: Union[Field, str], value: str) -> Query:
-    if isinstance(qfield, Field):
+def qwildcard(qfield: Union[ElasticField, str], value: str) -> Query:
+    if isinstance(qfield, ElasticField):
         qfield = qfield.path
     return Q("wildcard", **{qfield: {"value": value}})
 
 
 all_source_fields: list = [
-    CollectionAttribute.NODEREF_ID,
-    CollectionAttribute.TYPE,
-    CollectionAttribute.NAME,
+    ElasticResourceAttribute.NODEREF_ID,
+    ElasticResourceAttribute.TYPE,
+    ElasticResourceAttribute.NAME,
     CollectionAttribute.TITLE,
-    CollectionAttribute.KEYWORDS,
+    ElasticResourceAttribute.KEYWORDS,
     CollectionAttribute.DESCRIPTION,
     CollectionAttribute.PATH,
     CollectionAttribute.PARENT_ID,
@@ -76,7 +72,7 @@ def missing_attributes_search(
 missing_attributes_spec = {
     "title": Coalesce(CollectionAttribute.TITLE.path, default=""),
     "keywords": (
-        Coalesce(CollectionAttribute.KEYWORDS.path, default=[]),
+        Coalesce(ElasticResourceAttribute.KEYWORDS.path, default=[]),
         Iter().all(),
     ),
     "description": Coalesce(CollectionAttribute.DESCRIPTION.path, default=""),
@@ -86,8 +82,8 @@ missing_attributes_spec = {
     ),
     "parent_id": Coalesce(CollectionAttribute.PARENT_ID.path, default=""),
     "noderef_id": Coalesce(CollectionAttribute.NODE_ID.path, default=""),
-    "name": Coalesce(CollectionAttribute.NAME.path, default=""),
-    "type": Coalesce(CollectionAttribute.TYPE.path, default=""),
+    "name": Coalesce(ElasticResourceAttribute.NAME.path, default=""),
+    "type": Coalesce(ElasticResourceAttribute.TYPE.path, default=""),
     "children": Coalesce("", default=[]),  # workaround to map easier to pydantic model
 }
 
@@ -107,8 +103,8 @@ async def collections_with_missing_attributes(
 
 
 missingPropertyFilter = [
-    _CollectionAttribute.TITLE,
+    CollectionAttribute.TITLE,
     ElasticResourceAttribute.NAME,
     ElasticResourceAttribute.KEYWORDS,
-    _CollectionAttribute.DESCRIPTION,
+    CollectionAttribute.DESCRIPTION,
 ]

--- a/src/app/api/collections/missing_attributes.py
+++ b/src/app/api/collections/missing_attributes.py
@@ -1,0 +1,199 @@
+from typing import Optional, TypeVar, Union
+from uuid import UUID
+
+from elasticsearch_dsl.query import Q, Query
+from elasticsearch_dsl.response import Response
+from fastapi.params import Path
+from fastapi.params import Query as ParamQuery
+from glom import Coalesce, Iter, glom
+from pydantic import BaseModel
+
+from app.api.collections.models import MissingMaterials
+from app.core.config import ELASTIC_TOTAL_SIZE
+from app.elastic.dsl import qbool, qmatch
+from app.elastic.elastic import ResourceType, type_filter
+from app.elastic.fields import Field
+from app.elastic.search import Search
+from app.models import CollectionAttribute
+
+MissingCollectionField = Field(
+    "MissingCollectionField",
+    [
+        (f.name, (f.value, f.field_type))
+        for f in [
+            CollectionAttribute.NAME,
+            CollectionAttribute.TITLE,
+            CollectionAttribute.KEYWORDS,
+            CollectionAttribute.DESCRIPTION,
+        ]
+    ],
+)
+
+
+class MissingAttributeFilter(BaseModel):
+    attr: MissingCollectionField
+
+    def __call__(self, query_dict: dict):
+        query_dict["must_not"] = qwildcard(qfield=self.attr, value="*")
+        return query_dict
+
+
+def collections_filter_params(
+    *, missing_attr: MissingCollectionField = Path(...)
+) -> MissingAttributeFilter:
+    return MissingAttributeFilter(attr=missing_attr.value)
+
+
+CollectionResponseField = Field(
+    "CollectionAttribute",
+    [(f.name, (f.value, f.field_type)) for f in CollectionAttribute],
+)
+
+
+def collection_response_fields(
+    *, response_fields: set[CollectionResponseField] = ParamQuery(None)
+) -> set[CollectionAttribute]:
+    return response_fields
+
+
+_COLLECTION = TypeVar("_COLLECTION")
+
+
+def qwildcard(qfield: Union[Field, str], value: str) -> Query:
+    if isinstance(qfield, Field):
+        qfield = qfield.path
+    return Q("wildcard", **{qfield: {"value": value}})
+
+
+all_source_fields: list = [
+    CollectionAttribute.NODEREF_ID,
+    CollectionAttribute.TYPE,
+    CollectionAttribute.NAME,
+    CollectionAttribute.TITLE,
+    CollectionAttribute.KEYWORDS,
+    CollectionAttribute.DESCRIPTION,
+    CollectionAttribute.PATH,
+    CollectionAttribute.PARENT_ID,
+]
+
+MissingCollectionField = Field(
+    "MissingCollectionField",
+    [
+        (f.name, (f.value, f.field_type))
+        for f in [
+            CollectionAttribute.NAME,
+            CollectionAttribute.TITLE,
+            CollectionAttribute.KEYWORDS,
+            CollectionAttribute.DESCRIPTION,
+        ]
+    ],
+)
+
+
+class MissingAttributeFilter(BaseModel):
+    attr: MissingCollectionField
+
+    def __call__(self, query_dict: dict):
+        query_dict["must_not"] = qwildcard(qfield=self.attr, value="*")
+        return query_dict
+
+
+async def get_child_collections_with_missing_attributes(
+    noderef_id: UUID,
+    missing_attr_filter: MissingAttributeFilter,
+    source_fields: Optional[set[CollectionAttribute]],
+    max_hits: Optional[int] = ELASTIC_TOTAL_SIZE,
+) -> list[MissingMaterials]:
+    return await get_many(
+        ancestor_id=noderef_id,
+        missing_attr_filter=missing_attr_filter,
+        source_fields=source_fields,
+        max_hits=max_hits,
+    )
+
+
+def hits_to_missing_attributes(hits: Response) -> list[MissingMaterials]:
+    collections = []
+    for hit in hits:
+        entry = hit.to_dict()
+        spec = {
+            "title": Coalesce(CollectionAttribute.TITLE.path, default=None),
+            "keywords": (
+                Coalesce(CollectionAttribute.KEYWORDS.path, default=[]),
+                Iter().all(),
+            ),
+            "description": Coalesce(CollectionAttribute.DESCRIPTION.path, default=None),
+            "path": (
+                Coalesce(CollectionAttribute.PATH.path, default=[]),
+                Iter().all(),
+            ),
+            "parent_id": Coalesce(CollectionAttribute.PARENT_ID.path, default=None),
+            "noderef_id": Coalesce(CollectionAttribute.NODE_ID.path, default=None),
+            "name": Coalesce(CollectionAttribute.NAME.path, default=None),
+            "type": Coalesce(CollectionAttribute.TYPE.path, default=None),
+        }
+        parsed_entry = glom(entry, spec)
+        if parsed_entry["title"] is not None:
+            collections.append(
+                MissingMaterials(
+                    noderef_id=parsed_entry["noderef_id"],
+                    title=parsed_entry["title"],
+                    children=[],
+                    parent_id=parsed_entry["parent_id"],
+                    keywords=parsed_entry["keywords"],
+                    name=parsed_entry["name"],
+                    description=parsed_entry["description"],
+                    type=parsed_entry["type"],
+                    path=parsed_entry["path"],
+                )
+            )
+    return collections
+
+
+async def get_many(
+    ancestor_id: Optional[UUID] = None,
+    missing_attr_filter: Optional[MissingAttributeFilter] = None,
+    max_hits: Optional[int] = ELASTIC_TOTAL_SIZE,
+    source_fields: Optional[set[CollectionAttribute]] = None,
+) -> list[MissingMaterials]:
+    query_dict = get_many_base_query(
+        resource_type=ResourceType.COLLECTION,
+        ancestor_id=ancestor_id,
+    )
+    if missing_attr_filter:
+        query_dict = missing_attr_filter.__call__(query_dict=query_dict)
+    s = Search().base_filters().query(qbool(**query_dict))
+
+    response = s.source()[:max_hits].execute()
+
+    if response.success():
+        # rewind to parse with elastic hit
+        return hits_to_missing_attributes(response)
+
+
+# TODO: eliminate; use query_many instead
+def get_many_base_query(
+    resource_type: ResourceType,
+    ancestor_id: Optional[UUID] = None,
+) -> dict:
+    query_dict = {"filter": [*type_filter[resource_type]]}
+
+    if ancestor_id:
+        prefix = "collections." if resource_type == ResourceType.MATERIAL else ""
+        query_dict["should"] = [
+            qmatch(**{f"{prefix}path": ancestor_id}),
+            qmatch(**{f"{prefix}nodeRef.id": ancestor_id}),
+        ]
+        query_dict["minimum_should_match"] = 1
+
+    return query_dict
+
+
+def filter_response_fields(
+    items: list[BaseModel], response_fields: set[Field] = None
+) -> list[BaseModel]:
+    if response_fields:
+        return [
+            i.copy(include={f.name.lower() for f in response_fields}) for i in items
+        ]
+    return items

--- a/src/app/api/collections/missing_attributes.py
+++ b/src/app/api/collections/missing_attributes.py
@@ -14,6 +14,14 @@ from app.elastic.elastic import ResourceType, type_filter
 from app.elastic.search import Search
 from app.models import CollectionAttribute, ElasticResourceAttribute
 
+missing_attribute_filter = [
+    CollectionAttribute.TITLE,
+    ElasticResourceAttribute.NAME,
+    ElasticResourceAttribute.KEYWORDS,
+    CollectionAttribute.DESCRIPTION,
+]
+
+
 all_source_fields: list = [
     ElasticResourceAttribute.NODEREF_ID,
     ElasticResourceAttribute.TYPE,
@@ -77,11 +85,3 @@ async def collections_with_missing_attributes(
         return map_elastic_response_to_model(
             response, missing_attributes_spec, MissingMaterials
         )
-
-
-missingPropertyFilter = [
-    CollectionAttribute.TITLE,
-    ElasticResourceAttribute.NAME,
-    ElasticResourceAttribute.KEYWORDS,
-    CollectionAttribute.DESCRIPTION,
-]

--- a/src/app/api/collections/models.py
+++ b/src/app/api/collections/models.py
@@ -13,3 +13,11 @@ class CollectionNode(BaseModel):
     title: Optional[str]  # might be none due to data model
     children: list[CollectionNode]
     parent_id: Optional[UUID]
+
+
+class MissingMaterials(CollectionNode):
+    keywords: list[str]
+    description: str
+    path: list[str]
+    type: str
+    name: str

--- a/src/app/api/collections/models.py
+++ b/src/app/api/collections/models.py
@@ -2,10 +2,13 @@ from __future__ import (  # Needed for recursive type annotation, can be dropped
     annotations,
 )
 
+from enum import Enum
 from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
+
+from app.models import ElasticResourceAttribute, _CollectionAttribute
 
 
 class CollectionNode(BaseModel):
@@ -21,3 +24,10 @@ class MissingMaterials(CollectionNode):
     path: list[str]
     type: str
     name: str
+
+
+class MissingPropertyFilter(Enum):
+    TITLE = _CollectionAttribute.TITLE
+    NAME = ElasticResourceAttribute.NAME
+    KEYWORDS = ElasticResourceAttribute.KEYWORDS
+    DESCRIPTION = _CollectionAttribute.DESCRIPTION

--- a/src/app/api/collections/models.py
+++ b/src/app/api/collections/models.py
@@ -16,6 +16,16 @@ class CollectionNode(BaseModel):
 
 
 class MissingMaterials(CollectionNode):
+    """
+    A model containing information about entries which miss, e.g, a description.
+    By returning this model the editors know enough about the entry to find and correct it
+
+    :param
+        description: a free text description of the context
+        path: the complete id path, i.e., from parent node id up to the root id of elastic search
+        type: Indicates the type of content, must be ccm:map in the current implementation
+    """
+
     keywords: list[str]
     description: str
     path: list[str]

--- a/src/app/api/collections/models.py
+++ b/src/app/api/collections/models.py
@@ -2,13 +2,10 @@ from __future__ import (  # Needed for recursive type annotation, can be dropped
     annotations,
 )
 
-from enum import Enum
 from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
-
-from app.models import ElasticResourceAttribute, _CollectionAttribute
 
 
 class CollectionNode(BaseModel):
@@ -24,10 +21,3 @@ class MissingMaterials(CollectionNode):
     path: list[str]
     type: str
     name: str
-
-
-class MissingPropertyFilter(Enum):
-    TITLE = _CollectionAttribute.TITLE
-    NAME = ElasticResourceAttribute.NAME
-    KEYWORDS = ElasticResourceAttribute.KEYWORDS
-    DESCRIPTION = _CollectionAttribute.DESCRIPTION

--- a/src/app/api/collections/tree.py
+++ b/src/app/api/collections/tree.py
@@ -5,7 +5,7 @@ from elasticsearch_dsl.response import Response
 from glom import Coalesce, Iter
 
 from app.api.collections.models import CollectionNode
-from app.api.collections.utils import hits_to_object
+from app.api.collections.utils import map_elastic_response_to_model
 from app.api.collections.vocabs import tree_from_vocabs
 from app.core.config import ELASTIC_TOTAL_SIZE
 from app.elastic.dsl import qbool, qterm
@@ -69,7 +69,9 @@ def tree_from_elastic(node_id: UUID) -> list[CollectionNode]:
     response: Response = tree_search(node_id).execute()
 
     if response.success():
-        collection = hits_to_object(response, collection_spec, CollectionNode)
+        collection = map_elastic_response_to_model(
+            response, collection_spec, CollectionNode
+        )
         return build_portal_tree(collection, node_id)
 
 

--- a/src/app/api/collections/tree.py
+++ b/src/app/api/collections/tree.py
@@ -10,7 +10,7 @@ from app.api.collections.vocabs import tree_from_vocabs
 from app.core.config import ELASTIC_TOTAL_SIZE
 from app.elastic.dsl import qbool, qterm
 from app.elastic.search import Search
-from app.models import CollectionAttribute
+from app.models import CollectionAttribute, ElasticResourceAttribute
 
 
 def build_portal_tree(collections: list, root_noderef_id: UUID) -> list[CollectionNode]:
@@ -51,7 +51,7 @@ def tree_search(node_id: UUID) -> Search:
 collection_spec = {
     "title": Coalesce(CollectionAttribute.TITLE.path, default=None),
     "keywords": (
-        Coalesce(CollectionAttribute.KEYWORDS.path, default=[]),
+        Coalesce(ElasticResourceAttribute.KEYWORDS.path, default=[]),
         Iter().all(),
     ),
     "description": Coalesce(CollectionAttribute.DESCRIPTION.path, default=None),

--- a/src/app/api/collections/utils.py
+++ b/src/app/api/collections/utils.py
@@ -8,9 +8,11 @@ from app.api.collections.models import CollectionNode, MissingMaterials
 T = TypeVar("T", CollectionNode, MissingMaterials)
 
 
-def hits_to_object(hits: Response, specs: dict, model: Generic[T]) -> list[T]:
+def map_elastic_response_to_model(
+    response: Response, specs: dict, model: Generic[T]
+) -> list[T]:
     collections = []
-    for hit in hits:
+    for hit in response:
         parsed_entry = glom(hit.to_dict(), specs)
         if parsed_entry["title"] is not None:
             collections.append(model(**parsed_entry))

--- a/src/app/api/collections/utils.py
+++ b/src/app/api/collections/utils.py
@@ -1,0 +1,17 @@
+from typing import Generic, TypeVar
+
+from elasticsearch_dsl.response import Response
+from glom import glom
+
+from app.api.collections.models import CollectionNode, MissingMaterials
+
+T = TypeVar("T", CollectionNode, MissingMaterials)
+
+
+def hits_to_object(hits: Response, specs: dict, model: Generic[T]) -> list[T]:
+    collections = []
+    for hit in hits:
+        parsed_entry = glom(hit.to_dict(), specs)
+        if parsed_entry["title"] is not None:
+            collections.append(model(**parsed_entry))
+    return collections

--- a/src/app/api/collections/utils.py
+++ b/src/app/api/collections/utils.py
@@ -11,9 +11,4 @@ T = TypeVar("T", CollectionNode, MissingMaterials)
 def map_elastic_response_to_model(
     response: Response, specs: dict, model: Generic[T]
 ) -> list[T]:
-    collections = []
-    for hit in response:
-        parsed_entry = glom(hit.to_dict(), specs)
-        if parsed_entry["title"] is not None:
-            collections.append(model(**parsed_entry))
-    return collections
+    return [model(**glom(hit.to_dict(), specs)) for hit in response]

--- a/src/app/api/score/models.py
+++ b/src/app/api/score/models.py
@@ -2,8 +2,7 @@ from itertools import chain
 
 from pydantic import BaseModel, Field
 
-from app.elastic.fields import ElasticField as ElasticField
-from app.elastic.fields import ElasticFieldType
+from app.elastic.fields import ElasticField, ElasticFieldType
 from app.models import ElasticResourceAttribute
 
 

--- a/src/app/api/score/models.py
+++ b/src/app/api/score/models.py
@@ -2,35 +2,35 @@ from itertools import chain
 
 from pydantic import BaseModel, Field
 
-from app.elastic.fields import Field as ElasticField
-from app.elastic.fields import FieldType
+from app.elastic.fields import ElasticField as ElasticField
+from app.elastic.fields import ElasticFieldType
 from app.models import ElasticResourceAttribute
 
 
 class _LearningMaterialAttribute(ElasticField):
-    TITLE = ("properties.cclom:title", FieldType.TEXT)
-    SUBJECTS = ("properties.ccm:taxonid", FieldType.TEXT)
-    SUBJECTS_DE = ("i18n.de_DE.ccm:taxonid", FieldType.TEXT)
-    WWW_URL = ("properties.ccm:wwwurl", FieldType.TEXT)
-    DESCRIPTION = ("properties.cclom:general_description", FieldType.TEXT)
-    LICENSES = ("properties.ccm:commonlicense_key", FieldType.TEXT)
-    COLLECTION_NODEREF_ID = ("collections.nodeRef.id", FieldType.TEXT)
-    COLLECTION_PATH = ("collections.path", FieldType.TEXT)
-    CONTENT_FULLTEXT = ("content.fulltext", FieldType.TEXT)
+    TITLE = ("properties.cclom:title", ElasticFieldType.TEXT)
+    SUBJECTS = ("properties.ccm:taxonid", ElasticFieldType.TEXT)
+    SUBJECTS_DE = ("i18n.de_DE.ccm:taxonid", ElasticFieldType.TEXT)
+    WWW_URL = ("properties.ccm:wwwurl", ElasticFieldType.TEXT)
+    DESCRIPTION = ("properties.cclom:general_description", ElasticFieldType.TEXT)
+    LICENSES = ("properties.ccm:commonlicense_key", ElasticFieldType.TEXT)
+    COLLECTION_NODEREF_ID = ("collections.nodeRef.id", ElasticFieldType.TEXT)
+    COLLECTION_PATH = ("collections.path", ElasticFieldType.TEXT)
+    CONTENT_FULLTEXT = ("content.fulltext", ElasticFieldType.TEXT)
     LEARNINGRESOURCE_TYPE = (
         "properties.ccm:oeh_lrt_aggregated",
-        FieldType.TEXT,
+        ElasticFieldType.TEXT,
     )
     LEARNINGRESOURCE_TYPE_DE = (
         "i18n.de_DE.ccm:oeh_lrt_aggregated",
-        FieldType.TEXT,
+        ElasticFieldType.TEXT,
     )
     EDUENDUSERROLE_DE = (
         "i18n.de_DE.ccm:educationalintendedenduserrole",
-        FieldType.TEXT,
+        ElasticFieldType.TEXT,
     )
-    CONTAINS_ADS = ("properties.ccm:containsAdvertisement", FieldType.TEXT)
-    OBJECT_TYPE = ("properties.ccm:objecttype", FieldType.TEXT)
+    CONTAINS_ADS = ("properties.ccm:containsAdvertisement", ElasticFieldType.TEXT)
+    OBJECT_TYPE = ("properties.ccm:objecttype", ElasticFieldType.TEXT)
 
 
 LearningMaterialAttribute = ElasticField(

--- a/src/app/api/score/score.py
+++ b/src/app/api/score/score.py
@@ -14,7 +14,7 @@ from app.elastic.elastic import (
     query_missing_material_license,
 )
 from app.elastic.search import Search
-from app.models import CollectionAttribute
+from app.models import CollectionAttribute, ElasticResourceAttribute
 
 material_terms_relevant_for_score = [
     "missing_title",
@@ -116,11 +116,11 @@ aggs_material_validation = {
 aggs_collection_validation = {
     "missing_title": amissing(qfield=CollectionAttribute.TITLE),
     "short_title": afilter(Q("range", char_count_title={"gt": 0, "lt": 5})),
-    "missing_keywords": amissing(qfield=CollectionAttribute.KEYWORDS),
+    "missing_keywords": amissing(qfield=ElasticResourceAttribute.KEYWORDS),
     "few_keywords": afilter(Q("range", token_count_keywords={"gt": 0, "lt": 3})),
     "missing_description": amissing(qfield=CollectionAttribute.DESCRIPTION),
     "short_description": afilter(
         Q("range", char_count_description={"gt": 0, "lt": 30})
     ),
-    "missing_edu_context": amissing(qfield=CollectionAttribute.EDU_CONTEXT),
+    "missing_edu_context": amissing(qfield=ElasticResourceAttribute.EDU_CONTEXT),
 }

--- a/src/app/elastic/dsl.py
+++ b/src/app/elastic/dsl.py
@@ -4,16 +4,16 @@ from elasticsearch_dsl import A, Q
 from elasticsearch_dsl.aggs import Agg
 from elasticsearch_dsl.query import Query
 
-from .fields import Field
+from .fields import ElasticField
 from .utils import handle_text_field
 
 
-def qterm(qfield: Union[Field, str], value, **kwargs) -> Query:
+def qterm(qfield: Union[ElasticField, str], value, **kwargs) -> Query:
     kwargs[handle_text_field(qfield)] = value
     return Q("term", **kwargs)
 
 
-def qterms(qfield: Union[Field, str], values: list, **kwargs) -> Query:
+def qterms(qfield: Union[ElasticField, str], values: list, **kwargs) -> Query:
     kwargs[handle_text_field(qfield)] = values
     return Q("terms", **kwargs)
 
@@ -26,8 +26,8 @@ def qbool(**kwargs) -> Query:
     return Q("bool", **kwargs)
 
 
-def qexists(qfield: Union[Field, str], **kwargs) -> Query:
-    if isinstance(qfield, Field):
+def qexists(qfield: Union[ElasticField, str], **kwargs) -> Query:
+    if isinstance(qfield, ElasticField):
         qfield = qfield.path
     return Q("exists", field=qfield, **kwargs)
 
@@ -47,5 +47,5 @@ def afilter(query: Query) -> Agg:
     return A("filter", query)
 
 
-def amissing(qfield: Union[Field, str]) -> Agg:
+def amissing(qfield: Union[ElasticField, str]) -> Agg:
     return A("missing", field=handle_text_field(qfield))

--- a/src/app/elastic/fields.py
+++ b/src/app/elastic/fields.py
@@ -1,13 +1,13 @@
 from enum import Enum, auto
 
 
-class FieldType(str, Enum):
+class ElasticFieldType(str, Enum):
     KEYWORD = auto()
     TEXT = auto()
 
 
-class Field(str, Enum):
-    def __new__(cls, path: str, field_type: FieldType):
+class ElasticField(str, Enum):
+    def __new__(cls, path: str, field_type: ElasticFieldType):
         obj = str.__new__(cls, [path])
         obj._value_ = path
         obj.path = path

--- a/src/app/elastic/utils.py
+++ b/src/app/elastic/utils.py
@@ -5,7 +5,7 @@ from elasticsearch_dsl import connections
 from app.core.config import ELASTICSEARCH_TIMEOUT, ELASTICSEARCH_URL
 from app.core.logging import logger
 
-from .fields import Field, FieldType
+from .fields import ElasticField, ElasticFieldType
 
 
 async def connect_to_elastic():
@@ -16,10 +16,10 @@ async def connect_to_elastic():
     )
 
 
-def handle_text_field(qfield: Union[Field, str]) -> str:
-    if isinstance(qfield, Field):
+def handle_text_field(qfield: Union[ElasticField, str]) -> str:
+    if isinstance(qfield, ElasticField):
         qfield_key = qfield.path
-        if qfield.field_type is FieldType.TEXT:
+        if qfield.field_type is ElasticFieldType.TEXT:
             qfield_key = f"{qfield_key}.keyword"
         return qfield_key
     else:

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -9,6 +9,7 @@ _DESCENDANT_COLLECTIONS_MATERIALS_COUNTS = TypeVar(
 )
 
 
+# TODO: Refactor! This code cannot be refactored or indexed properly, right now. Reduce complexity, e.g., see field
 class ElasticResourceAttribute(Field):
     NODEREF_ID = ("nodeRef.id", FieldType.KEYWORD)
     TYPE = ("type", FieldType.KEYWORD)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -8,6 +8,8 @@ _DESCENDANT_COLLECTIONS_MATERIALS_COUNTS = TypeVar(
 )
 
 
+# TODO: distinguish better what ElasticResourceAttribute and CollectionAttribute do, how they differ
+#  and why there additional context is meaningful
 class ElasticResourceAttribute(ElasticField):
     EDU_CONTEXT = ("properties.ccm:educationalcontext", ElasticFieldType.TEXT)
     EDU_CONTEXT_DE = ("i18n.de_DE.ccm:educationalcontext", ElasticFieldType.TEXT)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,7 +1,6 @@
-from itertools import chain
 from typing import TypeVar
 
-from app.elastic.fields import Field, FieldType
+from app.elastic.fields import ElasticField, ElasticFieldType
 
 _ELASTIC_RESOURCE = TypeVar("_ELASTIC_RESOURCE")
 _DESCENDANT_COLLECTIONS_MATERIALS_COUNTS = TypeVar(
@@ -9,33 +8,23 @@ _DESCENDANT_COLLECTIONS_MATERIALS_COUNTS = TypeVar(
 )
 
 
-# TODO: Refactor! This code cannot be refactored or indexed properly, right now. Reduce complexity, e.g., see field
-class ElasticResourceAttribute(Field):
-    NODEREF_ID = ("nodeRef.id", FieldType.KEYWORD)
-    TYPE = ("type", FieldType.KEYWORD)
-    NAME = ("properties.cm:name", FieldType.TEXT)
-    PERMISSION_READ = ("permissions.Read", FieldType.TEXT)
-    EDU_METADATASET = ("properties.cm:edu_metadataset", FieldType.TEXT)
-    PROTOCOL = ("nodeRef.storeRef.protocol", FieldType.KEYWORD)
-    FULLPATH = ("fullpath", FieldType.KEYWORD)
-    KEYWORDS = ("properties.cclom:general_keyword", FieldType.TEXT)
-    EDU_CONTEXT = ("properties.ccm:educationalcontext", FieldType.TEXT)
-    EDU_CONTEXT_DE = ("i18n.de_DE.ccm:educationalcontext", FieldType.TEXT)
-    REPLICATION_SOURCE_DE = ("replicationsource", FieldType.TEXT)
+class ElasticResourceAttribute(ElasticField):
+    EDU_CONTEXT = ("properties.ccm:educationalcontext", ElasticFieldType.TEXT)
+    EDU_CONTEXT_DE = ("i18n.de_DE.ccm:educationalcontext", ElasticFieldType.TEXT)
+    EDU_METADATASET = ("properties.cm:edu_metadataset", ElasticFieldType.TEXT)
+    FULLPATH = ("fullpath", ElasticFieldType.KEYWORD)
+    KEYWORDS = ("properties.cclom:general_keyword", ElasticFieldType.TEXT)
+    NAME = ("properties.cm:name", ElasticFieldType.TEXT)
+    NODEREF_ID = ("nodeRef.id", ElasticFieldType.KEYWORD)
+    PERMISSION_READ = ("permissions.Read", ElasticFieldType.TEXT)
+    PROTOCOL = ("nodeRef.storeRef.protocol", ElasticFieldType.KEYWORD)
+    REPLICATION_SOURCE_DE = ("replicationsource", ElasticFieldType.TEXT)
+    TYPE = ("type", ElasticFieldType.KEYWORD)
 
 
-class _CollectionAttribute(Field):
-    TITLE = ("properties.cm:title", FieldType.TEXT)
-    DESCRIPTION = ("properties.cm:description", FieldType.TEXT)
-    PATH = ("path", FieldType.KEYWORD)
-    PARENT_ID = ("parentRef.id", FieldType.KEYWORD)
-    NODE_ID = ("nodeRef.id", FieldType.KEYWORD)
-
-
-CollectionAttribute = Field(
-    "CollectionAttribute",
-    [
-        (f.name, (f.value, f.field_type))
-        for f in chain(ElasticResourceAttribute, _CollectionAttribute)
-    ],
-)
+class CollectionAttribute(ElasticField):
+    DESCRIPTION = ("properties.cm:description", ElasticFieldType.TEXT)
+    PARENT_ID = ("parentRef.id", ElasticFieldType.KEYWORD)
+    PATH = ("path", ElasticFieldType.KEYWORD)
+    NODE_ID = ("nodeRef.id", ElasticFieldType.KEYWORD)
+    TITLE = ("properties.cm:title", ElasticFieldType.TEXT)

--- a/tests/unit_tests/crud/test_missing_attributes.py
+++ b/tests/unit_tests/crud/test_missing_attributes.py
@@ -5,15 +5,17 @@ from elasticsearch_dsl import AttrDict
 from app.api.collections.missing_attributes import (
     missing_attributes_search,
     missing_attributes_spec,
+    missingPropertyFilter,
 )
-from app.api.collections.models import MissingMaterials, MissingPropertyFilter
+from app.api.collections.models import MissingMaterials
 from app.api.collections.utils import map_elastic_response_to_model
 
 
 def test_missing_attributes_search():
     dummy_uuid = uuid.uuid4()
-    dummy_attribute = "properties.cclom:general_keyword"
-    dummy_missing_attribute = MissingPropertyFilter.KEYWORDS.value
+    dummy_attribute = "properties.cm:title"
+    dummy_missing_attribute = missingPropertyFilter[0].value
+    print(dummy_missing_attribute)
     dummy_maximum_size = 3
     search = missing_attributes_search(
         dummy_uuid, dummy_missing_attribute, dummy_maximum_size

--- a/tests/unit_tests/crud/test_missing_attributes.py
+++ b/tests/unit_tests/crud/test_missing_attributes.py
@@ -8,7 +8,7 @@ from app.api.collections.missing_attributes import (
     missing_attributes_spec,
 )
 from app.api.collections.models import MissingMaterials
-from app.api.collections.utils import hits_to_object
+from app.api.collections.utils import map_elastic_response_to_model
 
 
 def test_missing_attributes_search():
@@ -85,7 +85,9 @@ def test_hits_to_missing_attributes():
     }
 
     mocked_response = [AttrDict(entry)]
-    result = hits_to_object(mocked_response, missing_attributes_spec, MissingMaterials)
+    result = map_elastic_response_to_model(
+        mocked_response, missing_attributes_spec, MissingMaterials
+    )
     assert len(result) == 1
     assert len(result[0].children) == 0
     assert result[0].description == ""

--- a/tests/unit_tests/crud/test_missing_attributes.py
+++ b/tests/unit_tests/crud/test_missing_attributes.py
@@ -3,18 +3,17 @@ import uuid
 from elasticsearch_dsl import AttrDict
 
 from app.api.collections.missing_attributes import (
-    MissingAttributeFilter,
     missing_attributes_search,
     missing_attributes_spec,
 )
-from app.api.collections.models import MissingMaterials
+from app.api.collections.models import MissingMaterials, MissingPropertyFilter
 from app.api.collections.utils import map_elastic_response_to_model
 
 
 def test_missing_attributes_search():
     dummy_uuid = uuid.uuid4()
     dummy_attribute = "properties.cclom:general_keyword"
-    dummy_missing_attribute = MissingAttributeFilter(attr=dummy_attribute)
+    dummy_missing_attribute = MissingPropertyFilter.KEYWORDS.value
     dummy_maximum_size = 3
     search = missing_attributes_search(
         dummy_uuid, dummy_missing_attribute, dummy_maximum_size

--- a/tests/unit_tests/crud/test_missing_attributes.py
+++ b/tests/unit_tests/crud/test_missing_attributes.py
@@ -15,7 +15,6 @@ def test_missing_attributes_search():
     dummy_uuid = uuid.uuid4()
     dummy_attribute = "properties.cm:title"
     dummy_missing_attribute = missing_attribute_filter[0].value
-    print(dummy_missing_attribute)
     dummy_maximum_size = 3
     search = missing_attributes_search(
         dummy_uuid, dummy_missing_attribute, dummy_maximum_size

--- a/tests/unit_tests/crud/test_missing_attributes.py
+++ b/tests/unit_tests/crud/test_missing_attributes.py
@@ -3,9 +3,9 @@ import uuid
 from elasticsearch_dsl import AttrDict
 
 from app.api.collections.missing_attributes import (
+    missing_attribute_filter,
     missing_attributes_search,
     missing_attributes_spec,
-    missingPropertyFilter,
 )
 from app.api.collections.models import MissingMaterials
 from app.api.collections.utils import map_elastic_response_to_model
@@ -14,7 +14,7 @@ from app.api.collections.utils import map_elastic_response_to_model
 def test_missing_attributes_search():
     dummy_uuid = uuid.uuid4()
     dummy_attribute = "properties.cm:title"
-    dummy_missing_attribute = missingPropertyFilter[0].value
+    dummy_missing_attribute = missing_attribute_filter[0].value
     print(dummy_missing_attribute)
     dummy_maximum_size = 3
     search = missing_attributes_search(

--- a/tests/unit_tests/crud/test_missing_attributes.py
+++ b/tests/unit_tests/crud/test_missing_attributes.py
@@ -1,0 +1,93 @@
+import uuid
+
+from elasticsearch_dsl import AttrDict
+
+from app.api.collections.missing_attributes import (
+    MissingAttributeFilter,
+    missing_attributes_search,
+    missing_attributes_spec,
+)
+from app.api.collections.models import MissingMaterials
+from app.api.collections.utils import hits_to_object
+
+
+def test_missing_attributes_search():
+    dummy_uuid = uuid.uuid4()
+    dummy_attribute = "properties.cclom:general_keyword"
+    dummy_missing_attribute = MissingAttributeFilter(attr=dummy_attribute)
+    dummy_maximum_size = 3
+    search = missing_attributes_search(
+        dummy_uuid, dummy_missing_attribute, dummy_maximum_size
+    )
+    assert search.to_dict() == {
+        "_source": {
+            "includes": [
+                "nodeRef.id",
+                "type",
+                "properties.cm:name",
+                "properties.cm:title",
+                "properties.cclom:general_keyword",
+                "properties.cm:description",
+                "path",
+                "parentRef.id",
+            ]
+        },
+        "from": 0,
+        "query": {
+            "bool": {
+                "filter": [
+                    {"term": {"permissions.Read.keyword": "GROUP_EVERYONE"}},
+                    {"term": {"properties.cm:edu_metadataset.keyword": "mds_oeh"}},
+                    {"term": {"nodeRef.storeRef.protocol": "workspace"}},
+                    {"term": {"type": "ccm:map"}},
+                ],
+                "minimum_should_match": 1,
+                "must_not": [{"wildcard": {dummy_attribute: {"value": "*"}}}],
+                "should": [
+                    {"match": {"path": dummy_uuid}},
+                    {"match": {"nodeRef.id": dummy_uuid}},
+                ],
+            }
+        },
+        "size": dummy_maximum_size,
+    }
+
+
+def test_hits_to_missing_attributes():
+    parent_ref = uuid.uuid4()
+    node_ref = uuid.uuid4()
+    entry = {
+        "path": [
+            "00abdb05-6c96-4604-831c-b9846eae7d2d",
+            "c73dd8be-e520-42bb-b6f1-f989714d09fc",
+            "d1afbeaa-1d20-4d1d-a1aa-8d8903edff38",
+            "3305f552-c931-4bcc-842b-939c99752bd5",
+            "ef7e295e-d931-49eb-b1e2-76475f849e8a",
+            "572c19f6-37df-4090-a116-cc93b648785d",
+            "7050d184-db61-4e4b-86a0-74f35604a7da",
+            "7dfccbf5-191f-4856-849a-0e6c11ff1a8d",
+            "4156d4d0-79ec-4606-aab3-0133f0602561",
+            "35054614-72c8-49b2-9924-7b04c7f3bf71",
+            "5e40e372-735c-4b17-bbf7-e827a5702b57",
+            "742d8c87-e5a3-4658-86f9-419c2cea6574",
+            "db536584-55dc-4645-bc85-6ebe30c653b7",
+            "38c0c48e-f74f-45a5-9b11-e5d7dce526b3",
+        ],
+        "nodeRef": {"id": node_ref},
+        "type": "ccm:map",
+        "properties": {
+            "cm:title": "HTML",
+            "cm:name": "HTML",
+            "cclom:general_keyword": [""],
+            "cm:description": "",
+        },
+        "parentRef": {"id": parent_ref},
+    }
+
+    mocked_response = [AttrDict(entry)]
+    result = hits_to_object(mocked_response, missing_attributes_spec, MissingMaterials)
+    assert len(result) == 1
+    assert len(result[0].children) == 0
+    assert result[0].description == ""
+    assert result[0].parent_id == parent_ref
+    assert result[0].noderef_id == node_ref

--- a/tests/unit_tests/test_tree.py
+++ b/tests/unit_tests/test_tree.py
@@ -30,7 +30,7 @@ async def test_collection_tree():
     data = await collection_tree(root_node_id, use_vocabs=True)
     assert len(data) == 26
     count = node_count(data)
-    assert count == 2218  # adapt this number to the current state, may change regularly
+    assert count == 2217  # adapt this number to the current state, may change regularly
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Due to an unexpected entry in general_keywords for collection "Informatik", this endpoint failed in production and had to be mended.
The corresponding endpoint was transfered here.I refactored specificially enum unions which caused their entries to be hidden, the naming of certain elasticsearch code and generalized the usage of glom - the later could be replaced by our own implementation if we want to reduce dependencies.