### PR TITLE
fix:manual cherrypick of 60aab35ae4dabc1505c4e8a69473f247dc4f829d

### DIFF
--- a/src/app/elastic/elastic.py
+++ b/src/app/elastic/elastic.py
@@ -47,7 +47,8 @@ def query_materials(ancestor_id: UUID = None) -> Query:
 
 
 def query_missing_material_license() -> Query:
-    qfield = LearningMaterialAttribute.LICENSES
+    # use keyword field for exact match, no token matching
+    qfield = "properties.ccm:commonlicense_key.keyword"
     return qboolor(
         [
             qterms(


### PR DESCRIPTION
hotfix wrong results cause of license toxenization