### PR TITLE
Ignore series child objects

### DIFF
--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -388,8 +388,8 @@ async def get_collection_validation(
     node_id: uuid.UUID = Depends(toplevel_collections),
 ):
     """
-    Returns the number of collections missing certain properties for this collection's 'node_id' and its
-    sub-collections.
+    Returns a list of child collections of the given parent collection where
+    `title`, `description`, `keywords`, or `edu_context` are missing.
     """
     return collection_validation(node_id)
 
@@ -406,11 +406,12 @@ async def get_material_validation(
     node_id: uuid.UUID = Depends(toplevel_collections),
 ):
     """
-    Returns the number of materials missing certain properties for this collection's 'node_id' and its
+    Returns the ids of materials missing certain properties for this collection's 'node_id' and its
     sub-collections.
 
-    This endpoint is similar to '/analytics/node_id/validation/collections', but instead of showing missing
-    properties in collections, it counts the materials inside each collection that are missing that property.
+    This endpoint is similar to '/collections/{node_id}/collection-validation', but instead of listing missing
+    properties in the child collections, it selects the materials inside each collection by the
+    w.r.t. the materials missing properties.
 
     This endpoint relies on an internal periodic background process which is scheduled to regularly update the data.
     Its frequency can be configured via the BACKGROUND_TASK_TIME_INTERVAL environment variable.

--- a/src/app/api/collections/material_validation.py
+++ b/src/app/api/collections/material_validation.py
@@ -74,7 +74,6 @@ def _get_material_validation_single_collection(collection_id: uuid.UUID, title: 
     search = (
         MaterialSearch()
         .collection_filter(collection_id=collection_id, transitive=False)
-        .non_series_objects_filter()
         .missing_attribute_filter(**relevant_attributes)
         .extra(size=ELASTIC_TOTAL_SIZE, from_=0)
         .source(includes=["nodeRef.id"])

--- a/src/app/api/collections/material_validation.py
+++ b/src/app/api/collections/material_validation.py
@@ -103,16 +103,12 @@ def material_validation(collection_id: uuid.UUID) -> list[MaterialValidation]:
 
     :param collection_id: The id of top level collection
     """
-    node = tree(node_id=collection_id)
-    logger.info(f"Working on {node.title} ({collection_id})")
-    children = node.flatten(root=False)
+    collection_tree = tree(node_id=collection_id)
+    logger.info(f"Working on {collection_tree.title} ({collection_id})")
 
     return [
-        # fixme: we need to include the top level node here because we use a really inadequate data model...
-        #        and it needs to be included, because there could be materials that are only in the top level
-        #        collection and those materials would otherwise not be included anywhere.
-        _get_material_validation_single_collection(collection_id, title=node.title),
-        *(_get_material_validation_single_collection(child.node_id, title=child.title) for child in children),
+        _get_material_validation_single_collection(collection_id, title=node.title)
+        for node in collection_tree.flatten(root=True)
     ]
 
 

--- a/src/app/api/collections/pending_materials.py
+++ b/src/app/api/collections/pending_materials.py
@@ -90,7 +90,6 @@ async def pending_materials(
     search = (
         MaterialSearch()
         .collection_filter(collection_id=collection_id, transitive=True)
-        .non_series_objects_filter()
         .missing_attribute_filter(missing=missing)
         .source(includes=[attr.path for attr in source])
         .extra(size=ELASTIC_TOTAL_SIZE, from_=0)

--- a/src/app/elastic/search.py
+++ b/src/app/elastic/search.py
@@ -118,6 +118,7 @@ class MaterialSearch(_Search):
             filter=[
                 *_base_filters,
                 Term(**{ElasticResourceAttribute.TYPE.path: "ccm:io"}),  # fixme: why not keyword?
+                Bool(**{"must_not": [{"term": {"aspects": "ccm:io_childobject"}}]}),  # ignore child objects
             ]
         )
 
@@ -152,7 +153,3 @@ class MaterialSearch(_Search):
     #     # for attr in attributes:
     #     #     assert attr in material_attributes, f"{attr} is non a valid material attribute"
     #     return super().source(fields=[attr.path for attr in attributes])
-
-    def non_series_objects_filter(self) -> MaterialSearch:
-        """Only return materials that are not series objects."""
-        return self.filter(Bool(**{"must_not": [{"term": {"aspects": "ccm:io_childobject"}}]}))

--- a/tests/collections/test_counts.py
+++ b/tests/collections/test_counts.py
@@ -23,6 +23,7 @@ def test_query_collection_counts():
                     {"term": {"properties.cm:edu_metadataset.keyword": "mds_oeh"}},
                     {"term": {"nodeRef.storeRef.protocol": "workspace"}},
                     {"term": {"type": "ccm:io"}},
+                    {'bool': {'must_not': [{'term': {'aspects': 'ccm:io_childobject'}}]}},
                     {
                         "bool": {
                             "should": [
@@ -59,6 +60,7 @@ def test_query_collection_counts_oer():
                     {"term": {"properties.cm:edu_metadataset.keyword": "mds_oeh"}},
                     {"term": {"nodeRef.storeRef.protocol": "workspace"}},
                     {"term": {"type": "ccm:io"}},
+                    {'bool': {'must_not': [{'term': {'aspects': 'ccm:io_childobject'}}]}},
                     {
                         "terms": {
                             "properties.ccm:commonlicense_key.keyword": [

--- a/tests/resources/material-counts-request.json
+++ b/tests/resources/material-counts-request.json
@@ -24,6 +24,17 @@
         },
         {
           "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "aspects": "ccm:io_childobject"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
             "should": [
               {
                 "term": {

--- a/tests/resources/material-search-score-request.json
+++ b/tests/resources/material-search-score-request.json
@@ -24,6 +24,17 @@
         },
         {
           "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "aspects": "ccm:io_childobject"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
             "should": [
               {
                 "term": {

--- a/tests/resources/material-validation-single-collection-request.json
+++ b/tests/resources/material-validation-single-collection-request.json
@@ -23,11 +23,6 @@
           }
         },
         {
-          "term": {
-            "collections.nodeRef.id.keyword": "4940d5da-9b21-4ec0-8824-d16e0409e629"
-          }
-        },
-        {
           "bool": {
             "must_not": [
               {
@@ -36,6 +31,11 @@
                 }
               }
             ]
+          }
+        },
+        {
+          "term": {
+            "collections.nodeRef.id.keyword": "4940d5da-9b21-4ec0-8824-d16e0409e629"
           }
         },
         {

--- a/tests/resources/materials-by-collection-id-request.json
+++ b/tests/resources/materials-by-collection-id-request.json
@@ -23,6 +23,17 @@
           }
         },
         {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "aspects": "ccm:io_childobject"
+                }
+              }
+            ]
+          }
+        },
+        {
           "terms": {
             "properties.ccm:commonlicense_key.keyword": [
               "CC_0",

--- a/tests/resources/materials-by-collection-title-request.json
+++ b/tests/resources/materials-by-collection-title-request.json
@@ -23,6 +23,17 @@
           }
         },
         {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "aspects": "ccm:io_childobject"
+                }
+              }
+            ]
+          }
+        },
+        {
           "terms": {
             "properties.ccm:commonlicense_key.keyword": [
               "CC_0",

--- a/tests/resources/pending-materials-description-request.json
+++ b/tests/resources/pending-materials-description-request.json
@@ -22,6 +22,17 @@
             "type": "ccm:io"
           }
         },
+         {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "aspects": "ccm:io_childobject"
+                }
+              }
+            ]
+          }
+        },
         {
           "bool": {
             "should": [
@@ -33,17 +44,6 @@
               {
                 "match": {
                   "collections.path.keyword": "15fce411-54d9-467f-8f35-61ea374a298d"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "bool": {
-            "must_not": [
-              {
-                "term": {
-                  "aspects": "ccm:io_childobject"
                 }
               }
             ]

--- a/tests/resources/pending-materials-license-request.json
+++ b/tests/resources/pending-materials-license-request.json
@@ -22,6 +22,17 @@
             "type": "ccm:io"
           }
         },
+       {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "aspects": "ccm:io_childobject"
+                }
+              }
+            ]
+          }
+        },
         {
           "bool": {
             "should": [
@@ -33,17 +44,6 @@
               {
                 "match": {
                   "collections.path.keyword": "15fce411-54d9-467f-8f35-61ea374a298d"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "bool": {
-            "must_not": [
-              {
-                "term": {
-                  "aspects": "ccm:io_childobject"
                 }
               }
             ]

--- a/tests/resources/quality-matrix-collection-request.json
+++ b/tests/resources/quality-matrix-collection-request.json
@@ -24,6 +24,17 @@
         },
         {
           "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "aspects": "ccm:io_childobject"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
             "should": [
               {
                 "term": {

--- a/tests/resources/quality-matrix-replication-source-request.json
+++ b/tests/resources/quality-matrix-replication-source-request.json
@@ -24,6 +24,17 @@
         },
         {
           "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "aspects": "ccm:io_childobject"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
             "should": [
               {
                 "term": {

--- a/tests/test_elastic_search.py
+++ b/tests/test_elastic_search.py
@@ -10,6 +10,7 @@ def test_material_search():
                     {"term": {"properties.cm:edu_metadataset.keyword": "mds_oeh"}},
                     {"term": {"nodeRef.storeRef.protocol": "workspace"}},
                     {"term": {"type": "ccm:io"}},
+                    {'bool': {'must_not': [{'term': {'aspects': 'ccm:io_childobject'}}]}},
                 ]
             }
         }


### PR DESCRIPTION
This adds what was previously the `non_series_objects_filter` to the base filters of the material search.
This means, that child materials should now consistently be excluded from all exposed data (counts, score, etc).

Resolves #126 